### PR TITLE
Readme: Replaced relative image paths with absolutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ The death notice lets everyone know what killed you and how. The end game report
 
 | Chat Message (Before) | Chat Message (After) |
 | ----- | ----- |
-| ![Before](ExampleChatBefore.jpg) | ![After](ExampleChatAfter.jpg) |
+| ![Before](https://raw.githubusercontent.com/NotTsunami/ShowDeathCause/master/ExampleChatBefore.jpg) | ![After](https://raw.githubusercontent.com/NotTsunami/ShowDeathCause/master/ExampleChatAfter.jpg) |
 
 | Game End Report (Before) | Game End Report (After) |
 | ------ | ------ |
-| ![Before](ExampleBefore.jpg) | ![After](ExampleAfter.jpg) |
+| ![Before](https://raw.githubusercontent.com/NotTsunami/ShowDeathCause/master/ExampleBefore.jpg) | ![After](https://raw.githubusercontent.com/NotTsunami/ShowDeathCause/master/ExampleAfter.jpg) |
 
 _* The player is killed by the same type of monster, a Glacial Beetle, in both cases_
 


### PR DESCRIPTION
The Readme on the Thunderstore is a duplicate of this readme, meaning that when it tries to access the images located through a relative path `ExampleChatBefore.jpg`, it tries to load `https://thunderstore.io/package/NotTsunami/ShowDeathCause/ExampleChatBefore.jpg/`, which doesn't exist.